### PR TITLE
12MT walking test should use relative coordinates

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,7 +54,7 @@ dependencies {
 
     implementation 'net.openid:appauth:0.7.0'
 
-    implementation 'com.google.code.gson:gson:2.8.0'
+    implementation 'com.google.code.gson:gson:2.8.2'
     implementation 'com.google.guava:guava:23.2-android'
 
     implementation project(':researchstack-sdk')

--- a/app/src/main/java/org/sagebase/crf/step/Crf12MinWalkingStep.java
+++ b/app/src/main/java/org/sagebase/crf/step/Crf12MinWalkingStep.java
@@ -18,8 +18,6 @@
 package org.sagebase.crf.step;
 
 import org.researchstack.backbone.step.active.ActiveStep;
-import org.researchstack.backbone.step.active.recorder.AccelerometerRecorderConfig;
-import org.researchstack.backbone.step.active.recorder.DeviceMotionRecorderConfig;
 import org.researchstack.backbone.step.active.recorder.LocationRecorderConfig;
 import org.researchstack.backbone.step.active.recorder.RecorderConfig;
 
@@ -48,7 +46,8 @@ public class Crf12MinWalkingStep extends ActiveStep {
 
     private void commonInit() {
         List<RecorderConfig> configList = new ArrayList<>();
-        configList.add(new LocationRecorderConfig(LOCATION_RECORDER_ID));
+        configList.add(new LocationRecorderConfig.Builder().withIdentifier(LOCATION_RECORDER_ID)
+                .withUsesRelativeCoordinates(true).build());
         setRecorderConfigurationList(configList);
         setShouldContinueOnFinish(true);
         setShouldStartTimerAutomatically(true);

--- a/app/src/test/java/org/sagebase/crf/step/Crf12MinWalkingStepTest.java
+++ b/app/src/test/java/org/sagebase/crf/step/Crf12MinWalkingStepTest.java
@@ -1,0 +1,54 @@
+/*
+ *    Copyright 2018 Sage Bionetworks
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.sagebase.crf.step;
+
+import org.junit.Test;
+import org.researchstack.backbone.step.active.recorder.LocationRecorder;
+import org.researchstack.backbone.step.active.recorder.LocationRecorderConfig;
+import org.researchstack.backbone.step.active.recorder.RecorderConfig;
+
+import java.io.File;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class Crf12MinWalkingStepTest {
+    private static final String TEST_IDENTIFIER = "test-identifier";
+    private static final File MOCK_OUTPUT_DIRECTORY = mock(File.class);
+
+    @Test
+    public void testInit() {
+        Crf12MinWalkingStep step = new Crf12MinWalkingStep(TEST_IDENTIFIER);
+        assertEquals(TEST_IDENTIFIER, step.getIdentifier());
+
+        // The easiest way to check the recorder config is to make a recorder out of it.
+        List<RecorderConfig> recorderConfigList = step.getRecorderConfigurationList();
+        assertEquals(1, recorderConfigList.size());
+
+        LocationRecorderConfig config = (LocationRecorderConfig) recorderConfigList.get(0);
+        LocationRecorder recorder = (LocationRecorder) config.recorderForStep(step,
+                MOCK_OUTPUT_DIRECTORY);
+        assertEquals(Crf12MinWalkingStep.LOCATION_RECORDER_ID, recorder.getIdentifier());
+        assertSame(MOCK_OUTPUT_DIRECTORY, recorder.getOutputDirectory());
+        assertTrue(recorder.getUsesRelativeCoordinates());
+        assertSame(step, recorder.getStep());
+    }
+}


### PR DESCRIPTION
See https://sagebionetworks.jira.com/browse/AA-200

Pull in new LocationRecorder and set flag to use relative coordinates.

Testing done:
* gradlew check
* Manually tested. See sample result below

Pre-requisites:
* https://github.com/Sage-Bionetworks/BridgeAndroidSDK/pull/117
* https://github.com/ResearchStack/ResearchStack/pull/455

```json
    [ {
        "timestamp" : 1516956501823,
        "coordinate" : {
          "relativeLatitude" : 0.0,
          "relativeLongitude" : 0.0
        },
        "accuracy" : 1.7217771,
        "speed" : 0.1600249,
        "altitude" : 67.1097412109375
      }, {
        "timestamp" : 1516956504832,
        "coordinate" : {
          "relativeLatitude" : 1.2190433407965884E-4,
          "relativeLongitude" : -5.401029073937025E-5
        },
        "accuracy" : 3.1901002,
        "speed" : 0.59436053,
        "altitude" : 68.93077850341797
      }, {
        "timestamp" : 1516956507841,
        "coordinate" : {
          "relativeLatitude" : 2.3883909463506825E-6,
          "relativeLongitude" : 5.097386505781287E-6
        },
        "accuracy" : 2.3339722,
        "speed" : 0.10015512,
        "altitude" : 65.01776885986328
      } ]
```