### PR TITLE
Add uptime to BPM recorder samples

### DIFF
--- a/app/src/main/java/org/sagebase/crf/step/active/BpmRecorder.java
+++ b/app/src/main/java/org/sagebase/crf/step/active/BpmRecorder.java
@@ -184,6 +184,7 @@ public interface BpmRecorder {
         private static final float RED_INTENSITY_FACTOR_THRESHOLD = 2;
         private static final String TIMESTAMP_DATE_KEY = "timestampDate";
         private static final String TIMESTAMP_IN_SECONDS_KEY = "timestamp";
+        private static final String UPTIME_IN_SECONDS_KEY = "uptime";
         private static final String HEART_RATE_KEY = "bpm_camera";
         private static final String HUE_KEY = "hue";
         private static final String SATURATION_KEY = "saturation";
@@ -196,7 +197,9 @@ public interface BpmRecorder {
         
         private final JsonObject mJsonObject = new JsonObject();
 
-        private double timestampZeroReference = 0;
+        private double timestampZeroReference = -1;
+        private double uptimeZeroReference = -1;
+
         /**
          * Intelligent start is a feature that delays recording until
          * an algorithm determines the user's finger is in front of the camera
@@ -230,19 +233,26 @@ public interface BpmRecorder {
         public void onHeartRateSampleDetected(HeartBeatSample sample) {
             bpmCalculator.calculateBpm(sample);
 
-            if (timestampZeroReference <= 0) {
+            if (timestampZeroReference < 0) {
                 // set timestamp reference, which timestamps are measured relative to
                 timestampZeroReference = sample.t;
+                uptimeZeroReference = System.nanoTime() * 1e-9;
 
                 Date timestampReferenceDate = new Date(System.currentTimeMillis());
+                // TODO: syoung 10/04/2018 Figure out how to set timestamp dates to "en_US_POSIX"
                 mJsonObject.addProperty(TIMESTAMP_DATE_KEY,
                         new SimpleDateFormat(FormatHelper.DATE_FORMAT_ISO_8601, Locale.getDefault())
                                 .format(timestampReferenceDate));
                 LOG.debug("TIMESTAMP Date key: " + mJsonObject.get(TIMESTAMP_DATE_KEY).getAsString());
+            } else {
+                mJsonObject.remove(TIMESTAMP_DATE_KEY);
             }
 
-            
-            mJsonObject.addProperty(TIMESTAMP_IN_SECONDS_KEY,  sample.t / 1_000);
+            double relativeTimestamp = ((sample.t - timestampZeroReference) / 1_000);
+            double uptime = uptimeZeroReference + relativeTimestamp;
+
+            mJsonObject.addProperty(TIMESTAMP_IN_SECONDS_KEY, relativeTimestamp);
+            mJsonObject.addProperty(UPTIME_IN_SECONDS_KEY, uptime);
             mJsonObject.addProperty(HUE_KEY, sample.h);
             mJsonObject.addProperty(SATURATION_KEY, sample.s);
             mJsonObject.addProperty(BRIGHTNESS_KEY, sample.v);


### PR DESCRIPTION
Include both `uptime` and `timestamp` for all samples where the definitions of these keys match the schema used on iOS.

Note: Outstanding issue where I couldn't figure out how to set the locale. Should **not** be default.