### PR TITLE
STEP-76

### DIFF
--- a/crf/src/main/assets/json/heart_snapshot.json
+++ b/crf/src/main/assets/json/heart_snapshot.json
@@ -125,7 +125,8 @@
       "identifier"       : "hr",
       "type"             : "crf_heart_rate_camera_step",
       "isHrRecoveryStep" : "true",
-      "duration"         : "60"
+      "duration"         : "60",
+      "shouldRecordVideo": false
     },
     {
       "identifier"       : "completion",

--- a/crf/src/main/java/org/sagebase/crf/researchstack/CrfTaskFactory.java
+++ b/crf/src/main/java/org/sagebase/crf/researchstack/CrfTaskFactory.java
@@ -290,6 +290,8 @@ public class CrfTaskFactory extends TaskItemFactory {
         }
 
         step.isHrRecoveryStep = item.isHrRecoveryStep;
+        step.shouldRecordVideo = item.shouldRecordVideo;
+
         return step;
     }
 

--- a/crf/src/main/java/org/sagebase/crf/step/CrfHeartRateCameraStep.java
+++ b/crf/src/main/java/org/sagebase/crf/step/CrfHeartRateCameraStep.java
@@ -50,7 +50,7 @@ public class CrfHeartRateCameraStep extends ActiveStep {
 
 
     public boolean isHrRecoveryStep;
-
+    public boolean shouldRecordVideo;
 
     public CrfHeartRateCameraStep(String identifier, String title, String detailText) {
         super(identifier, title, detailText);

--- a/crf/src/main/java/org/sagebase/crf/step/CrfHeartRateStepLayout.java
+++ b/crf/src/main/java/org/sagebase/crf/step/CrfHeartRateStepLayout.java
@@ -284,8 +284,10 @@ public class CrfHeartRateStepLayout extends ActiveStepLayout implements
 
         HeartRateCameraRecorderConfig config =
                 new HeartRateCameraRecorderConfig(step.stepIdentifier);
-        cameraRecorder = config.recorderForStep(
-                cameraSourcePreview, activeStep, this, getOutputDirectory(getContext()));
+
+        cameraRecorder = config.recorderForStep(cameraSourcePreview, activeStep,
+                this, getOutputDirectory(getContext()), step.shouldRecordVideo);
+
         cameraRecorder.setRecorderListener(this);
 
         // camera1

--- a/crf/src/main/java/org/sagebase/crf/step/CrfHeartRateSurveyItem.java
+++ b/crf/src/main/java/org/sagebase/crf/step/CrfHeartRateSurveyItem.java
@@ -25,4 +25,7 @@ public class CrfHeartRateSurveyItem extends ActiveStepSurveyItem {
 
     @SerializedName("isHrRecoveryStep")
     public boolean isHrRecoveryStep;
+
+    @SerializedName("shouldRecordVideo")
+    public boolean shouldRecordVideo;
 }

--- a/crf/src/main/java/org/sagebase/crf/step/active/HeartRateCamera2Recorder.java
+++ b/crf/src/main/java/org/sagebase/crf/step/active/HeartRateCamera2Recorder.java
@@ -119,15 +119,17 @@ public class HeartRateCamera2Recorder extends Recorder {
     private final File mediaRecorderFile;
     private CameraCaptureSession cameraCaptureSession;
     private CameraManager manager;
-    
+    private boolean shouldRecordVideo;
     
     public HeartRateCamera2Recorder(String identifier, Step step, File outputDirectory,
-                                    CrfHeartRateStepLayout stepLayout) {
+                                    CrfHeartRateStepLayout stepLayout, boolean recordVideo) {
         super(identifier + "Video", step, outputDirectory);
         textureView = stepLayout.getCameraPreview();
     
         Context context = textureView.getContext();
-    
+
+        shouldRecordVideo = recordVideo;
+
         mediaRecorderFile = new File(getOutputDirectory(), uniqueFilename + ".mp4");
         subscriptions = new CompositeSubscription();
 
@@ -282,9 +284,12 @@ public class HeartRateCamera2Recorder extends Recorder {
         heartBeatJsonWriter.stop();
         subscriptions.unsubscribe();
 
+        if (!shouldRecordVideo && mediaRecorderFile.exists()) {
+            mediaRecorderFile.delete();
+        }
+
         //Check that the video file exists and has data before adding to results.
-        if (mediaRecorderFile.exists() && mediaRecorderFile.length() > 128) {
-            long length = mediaRecorderFile.length();
+        if (shouldRecordVideo && mediaRecorderFile.exists()) {
             FileResult fileResult = new FileResult(fileResultIdentifier(), mediaRecorderFile, MP4_CONTENT_TYPE);
             fileResult.setStartDate(startTime);
             fileResult.setEndDate(new Date());

--- a/crf/src/main/java/org/sagebase/crf/step/active/HeartRateCameraRecorderConfig.java
+++ b/crf/src/main/java/org/sagebase/crf/step/active/HeartRateCameraRecorderConfig.java
@@ -53,10 +53,12 @@ public class HeartRateCameraRecorderConfig extends RecorderConfig {
      */
     public Recorder recorderForStep(CameraSourcePreview cameraSourcePreview, Step step,
                                     CrfHeartRateStepLayout heartRateStepLayout,
-                                    File outputDirectory) {
+                                    File outputDirectory,
+                                    boolean recordVideo) {
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             return new HeartRateCamera2Recorder(getIdentifier(), step, outputDirectory,
-                    heartRateStepLayout);
+                    heartRateStepLayout, recordVideo);
         }
         return new HeartRateCameraRecorder(getIdentifier(), step, outputDirectory,
                 heartRateStepLayout, cameraSourcePreview);


### PR DESCRIPTION
mPower2 has the requirement where we are not allowed to upload the MP4 of the user doing the heart rate task, so this disables video result creation by default in the heart snapshot task.

Added new json field for toggling video result recording on/off so it can be added back in through JSON.  Tested both scenarios and they are working as expected.